### PR TITLE
Added ability for user to specify where they want the output file downloaded

### DIFF
--- a/iSpiEFP/resources/views/libEFP.fxml
+++ b/iSpiEFP/resources/views/libEFP.fxml
@@ -64,7 +64,7 @@
                 <Label text="Load a Preset:" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
                 <ComboBox fx:id="presets" maxWidth="Infinity" GridPane.rowIndex="0" GridPane.columnIndex="1"
                           promptText="None Selected"/>
-                <Label text="Title:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+                <Label text="Job Title:" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
                 <TextField fx:id="title" GridPane.rowIndex="1" GridPane.columnIndex="1" GridPane.columnSpan="3"
                            onAction="#updatelibEFPInputText" promptText="Enter title"/>
                 <Label text="Run Type:" GridPane.rowIndex="2" GridPane.columnIndex="0"/>
@@ -91,8 +91,11 @@
                           onAction="#updatelibEFPInputText"/>
                 <Label text="Auto submission: " GridPane.rowIndex="6" GridPane.columnIndex="2"/>
                 <ComboBox fx:id="auto_sub" maxWidth="Infinity" GridPane.rowIndex="6" GridPane.columnIndex="3"/>
+                <Label text="Target Directory: " GridPane.rowIndex="7"  GridPane.columnIndex="0" />
+                <TextField fx:id="localWorkingDirectory" GridPane.rowIndex="7" GridPane.columnIndex="1" />
+                <Button fx:id="findButton" text="Find" GridPane.rowIndex="7" GridPane.columnIndex="2" onAction="#findDirectory" />
                 <TextArea fx:id="libEFPInputTextArea" maxWidth="Infinity"
-                          GridPane.rowIndex="7" GridPane.columnIndex="0" GridPane.columnSpan="4" GridPane.rowSpan="3">
+                          GridPane.rowIndex="8" GridPane.columnIndex="0" GridPane.columnSpan="4" GridPane.rowSpan="3">
                 </TextArea>
                 <columnConstraints>
                     <ColumnConstraints percentWidth="20" hgrow="ALWAYS"/>

--- a/iSpiEFP/src/org/ispiefp/app/gamess/gamessInputController.java
+++ b/iSpiEFP/src/org/ispiefp/app/gamess/gamessInputController.java
@@ -543,7 +543,7 @@ public class gamessInputController implements Initializable {
                     outToServer.close();
 
                     //poll for job finishing
-                    JobManager jobManager = new JobManager(username, password, hostname, jobID, title, time, "QUEUE",
+                    JobManager jobManager = new JobManager(username, password, hostname, null, jobID, title, time, "QUEUE",
                             "GAMESS");
                     jobManager.watchJobStatus();
 

--- a/iSpiEFP/src/org/ispiefp/app/libEFP/libEFPInputController.java
+++ b/iSpiEFP/src/org/ispiefp/app/libEFP/libEFPInputController.java
@@ -12,6 +12,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.*;
+import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
@@ -67,7 +68,6 @@ public class libEFPInputController implements Initializable {
 
     @FXML
     private ComboBox<String> format;
-
 
     @FXML
     private ComboBox<String> elec_damp;
@@ -144,6 +144,8 @@ public class libEFPInputController implements Initializable {
     @FXML
     private ComboBox<String> server;
 
+    @FXML private TextField localWorkingDirectory;
+    @FXML Button findButton;
     @FXML
     private Button nextButton;
 
@@ -415,7 +417,9 @@ public class libEFPInputController implements Initializable {
         libEFPInputTextArea.setText(getlibEFPInputText() + "\n" + coordinates);
         libEFPInputTextArea2.setText(getlibEFPInputText() + "\n" + coordinates);
         libEFPInputTextArea3.setText(getlibEFPInputText() + "\n" + coordinates);
-        if (!server.getSelectionModel().isEmpty()) nextButton.setDisable(false);
+        if (!server.getSelectionModel().isEmpty() ||
+                (new File(localWorkingDirectory.getText()).exists() &&
+                        new File(localWorkingDirectory.getText()).isDirectory())) nextButton.setDisable(false);
     }
 
     public void generatelibEFPInputFile() {
@@ -685,7 +689,9 @@ public class libEFPInputController implements Initializable {
             submission.submit(subScriptCont.getUsersSubmissionScript());
             currentTime = dateFormat.format(date).toString();
             userPrefs.put(clusterjobID, clusterjobID + "\n" + currentTime + "\n");
-            JobManager jobManager = new JobManager(username, password, selectedServer.getHostname(), submission.outputFilename, title.getText(), currentTime, "QUEUE", "LIBEFP");
+            JobManager jobManager = new JobManager(username, password, selectedServer.getHostname(),
+                    localWorkingDirectory.getText(), submission.outputFilename, title.getText(),
+                    currentTime, "QUEUE", "LIBEFP");
             UserPreferences.getJobsMonitor().addJob(jobManager);
             Stage currentStage = (Stage) root.getScene().getWindow();
             currentStage.close();
@@ -907,6 +913,16 @@ public class libEFPInputController implements Initializable {
             }
         }
         return rmsdMap;
+    }
+
+    public void findDirectory(){
+        DirectoryChooser directoryChooser = new DirectoryChooser();
+        directoryChooser.setTitle("Select a Working Directory for Job: " + title.getText());
+        directoryChooser.setInitialDirectory(new File(System.getProperty("user.home")));
+        Stage currStage = (Stage) root.getScene().getWindow();
+
+        File file = directoryChooser.showDialog(currStage);
+        localWorkingDirectory.setText(file.getAbsolutePath());
     }
 
     // Handle SSH case later

--- a/iSpiEFP/src/org/ispiefp/app/server/JobManager.java
+++ b/iSpiEFP/src/org/ispiefp/app/server/JobManager.java
@@ -33,12 +33,15 @@ public class JobManager implements Runnable {
     private String type;
     private String outputFilename;
     private String stdoutputFilename;
+    private String localWorkingDirectory;
     private transient Connection conn;
 
-    public JobManager(String username, String password, String hostname, String jobID, String title, String date, String status, String type) {
+    public JobManager(String username, String password, String hostname, String localWorkingDirectory,
+                      String jobID, String title, String date, String status, String type) {
         this.username = username;
         this.password = password;
         this.hostname = hostname;
+        this.localWorkingDirectory = localWorkingDirectory;
         this.jobID = jobID;
         this.title = title;
         this.date = date;
@@ -122,7 +125,7 @@ public class JobManager implements Runnable {
      * Start a thread that watches a specific job and send a notification when the jobs completes
      */
     public void watchJobStatus() {
-        (new Thread(new JobManager(this.username, this.password, this.hostname, this.jobID, this.title, this.date, this.status, this.type))).start();
+        (new Thread(new JobManager(this.username, this.password, this.hostname, this.localWorkingDirectory, this.jobID, this.title, this.date, this.status, this.type))).start();
     }
 
     /*
@@ -429,6 +432,10 @@ public class JobManager implements Runnable {
         return hostname;
     }
 
+    public String getLocalWorkingDirectory() {
+        return localWorkingDirectory;
+    }
+
     public String getJobID() {
         return jobID;
     }
@@ -471,6 +478,10 @@ public class JobManager implements Runnable {
 
     public void setHostname(String hostname) {
         this.hostname = hostname;
+    }
+
+    public void setLocalWorkingDirectory(String localWorkingDirectory) {
+        this.localWorkingDirectory = localWorkingDirectory;
     }
 
     public void setJobID(String jobID) {

--- a/iSpiEFP/src/org/ispiefp/app/submission/JobsMonitor.java
+++ b/iSpiEFP/src/org/ispiefp/app/submission/JobsMonitor.java
@@ -1,8 +1,11 @@
 package org.ispiefp.app.submission;
 
 import com.google.gson.Gson;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.ispiefp.app.server.JobManager;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -87,12 +90,29 @@ public class JobsMonitor implements Runnable {
     }
 
     public void retrieveJob(JobManager jm){
-        String fileContents = "";
+        String outputFileContents = "";
+        String errorFileContents = "";
+        String outputFilePath = jm.getOutputFilename();
+        String errorFilePath = jm.getStdoutputFilename();
+        String outputFileName = outputFilePath.substring(outputFilePath.lastIndexOf(File.separatorChar) + 1);
+        String errorFileName = errorFilePath.substring(errorFilePath.lastIndexOf(File.separatorChar) + 1);
         try {
-            fileContents = jm.getRemoteFile(jm.getOutputFilename());
-        } catch (IOException e){ System.err.println("Was unable to retrieve the file for the completed job"); }
-        System.out.println("Attempting to print the retrieved file:");
-        System.out.println(fileContents);
+            outputFileContents = jm.getRemoteFile(jm.getOutputFilename());
+            errorFileContents = jm.getRemoteFile(jm.getStdoutputFilename());
+        } catch (IOException e){ System.err.println("Was unable to retrieve the files for the completed job"); }
+        File outputFile = new File(jm.getLocalWorkingDirectory() + File.separator + outputFileName);
+        try {
+            FileUtils.writeStringToFile(outputFile, outputFileContents, "UTF-8");
+        } catch (IOException e){
+            System.err.println("Was unable to write the output file locally");
+        }
+        File errorFile = new File(jm.getLocalWorkingDirectory() + File.separator + errorFileName);
+        try {
+            FileUtils.writeStringToFile(errorFile, errorFileContents, "UTF-8");
+        } catch (IOException e){
+            System.err.println("Was unable to write the error file locally");
+        }
+
     }
 
     public boolean checkForError(JobManager jm){

--- a/submission.slurm
+++ b/submission.slurm
@@ -1,8 +1,8 @@
 #!/bin/csh
-#SBATCH -o iSpiClient/Libefp/output/ethhhhannnol.stdout
-#SBATCH -A lslipche
+#SBATCH -o iSpiClient/Libefp/output/test1.stdout
+#SBATCH -A debug
 #SBATCH -N 1
 #SBATCH -n 20
 #SBATCH -t 00:30:00
-#SBATCH --mem=1000
-/depot/lslipche/apps/iSpiEFP/packages/libefp/bin/efpmd iSpiClient/Libefp/input/ethhhhannnol.in > iSpiClient/Libefp/output/ethhhhannnol.out
+#SBATCH --mem=10000
+/depot/lslipche/apps/iSpiEFP/packages/libefp/bin/efpmd iSpiClient/Libefp/input/test1.in > iSpiClient/Libefp/output/test1.out


### PR DESCRIPTION
Added a new text field in the libEFP submission window that allows the user to specify the directory where they would like the output files downloaded to. The thread responsible for monitoring for job completion will then download the file to the that directory when the job completes.